### PR TITLE
1 change websocket implementation to include internal version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 src/env.js
 
 environment/deployment.json
+src/deployment.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 
 src/env.js
+
+environment/deployment.json

--- a/environment/deployment.json
+++ b/environment/deployment.json
@@ -1,1 +1,0 @@
-{"env":"local", "branch":"1-change-websocket-implementation-to-include-internal-version", "commitSha":"8ea595715c2e5af4960f00d3c4820c2e4957de55", "timestamp":"1672606204"}

--- a/environment/deployment.json
+++ b/environment/deployment.json
@@ -1,1 +1,1 @@
-{"env":"local", "branch":"main", "commitSha":"3842bbed12279287535adba6bd99cd9bd3364cd7", "timestamp":"1672354478"}
+{"env":"local", "branch":"1-change-websocket-implementation-to-include-internal-version", "commitSha":"8ea595715c2e5af4960f00d3c4820c2e4957de55", "timestamp":"1672606204"}

--- a/src/App.js
+++ b/src/App.js
@@ -363,7 +363,6 @@ const PaymentForm = ({xumm, fromAccount}) => {
           setTxStatus(1);
         }, 5000);
       };      
-      
     }
 
     if (runtime.xapp) {

--- a/src/deployment.json
+++ b/src/deployment.json
@@ -1,1 +1,0 @@
-{"env":"local", "branch":"1-change-websocket-implementation-to-include-internal-version", "commitSha":"8ea595715c2e5af4960f00d3c4820c2e4957de55", "timestamp":"1672606204"}

--- a/src/deployment.json
+++ b/src/deployment.json
@@ -1,1 +1,1 @@
-{"env":"local", "branch":"main", "commitSha":"3842bbed12279287535adba6bd99cd9bd3364cd7", "timestamp":"1672354478"}
+{"env":"local", "branch":"1-change-websocket-implementation-to-include-internal-version", "commitSha":"8ea595715c2e5af4960f00d3c4820c2e4957de55", "timestamp":"1672606204"}


### PR DESCRIPTION
Added the native implementation of the Xumm payload creation with websocket subscription as an event with `create and subscribe`

```javascript
/**
   * uses the create and subscribe method from the xumm
   * SDK to listen for events
   * 
   * @param {*} xummSDK 
   * @param {*} xummPayload 
   */
  const handleTxPayloadNativeWS = async (xummSDK, xummPayload) => {
    try {
  
      const pong = await xummSDK.ping()
      console.log(pong.application)
  
      const payloadResponse = xummSDK.payload.createAndSubscribe(xummPayload, e => {
        console.log("event subscription",e.data);
        setWebsocketMessage(e.data);

        if (typeof e.data.signed !== 'undefined') {
          setTxStatus(1);
          setTxStatusMessage(`Payment signed.`);
          setPaymentPayload(null);
          setFormState({'destination': ''});

          // wait 5 seconds and then clear the message
          setTimeout(function () {
            setWebsocketMessage(null);
            setTxStatusMessage(null);
            setTxStatus(0);
          }, 5000);
            return e.data
          };

      });
  
      const r = await payloadResponse
      setPaymentPayload(await r.created);
      setTxStatusMessage("Listening for the TX Sign request to the Wallet.");

    } catch (e) {
      console.log({error: e.message, stack: e.stack})
    }
  }
  ``` 